### PR TITLE
Fixed unchanged '...' label on ubuntu 18.04

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,6 @@ const PopupMenu = imports.ui.popupMenu;
 const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
-const ByteArray = imports.byteArray;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
@@ -103,7 +102,7 @@ const PingMenuButton = new Lang.Class({
     _loadPipeOUT: function(channel, condition, data) {
         if (condition != GLib.IOCondition.HUP) {
             let [size, out] = channel.read_to_end();
-            let result = ByteArray.toString(out).match(/time=(\d*)/m);
+            let result = String.fromCharCode.apply(null, out).match(/time=(\d*)/m);
             if(result != null) {
                 let str = result[1];
                 str = str.concat(_(" ms"));


### PR DESCRIPTION
On ubuntu 18.04 (gnome-shell 3.28.4), the ByteArray.toString(out) returned as string describing a GObject. Therefore, the ping time could not be parsed.
Now, it both works on ubuntu 18.04 and debian 10 (gnome-shell 3.30.2) (it worked on debian 10 also before).